### PR TITLE
Fix resume link path to resolve 404 error

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,7 +13,7 @@ export const LINKS: {
 }, {
     link: "https://t.me/calvindotsg/", logo: "fa6-brands:telegram", name: "Telegram"
 }, {
-    link: "../assets/Calvin_Loh_Solutions_Engineer_Resume.pdf", logo: "ri:file-pdf-2-line", name: "Resume"
+    link: "/src/assets/Calvin_Loh_Solutions_Engineer_Resume.pdf", logo: "ri:file-pdf-2-line", name: "Resume"
 },];
 
 export const CAREER: {


### PR DESCRIPTION
Fixes #18

This PR resolves the broken resume link that was returning a 404 error.

## Changes
- Updated resume link from relative path `../assets/Calvin_Loh_Solutions_Engineer_Resume.pdf` to absolute path `/src/assets/Calvin_Loh_Solutions_Engineer_Resume.pdf`
- This ensures proper asset handling in Astro

## Testing
- Verified the resume file exists at the specified location
- Updated configuration in `src/lib/constants.ts`

Generated with [Claude Code](https://claude.ai/code)