### PR TITLE
chore(mcp): drop unused sequential-thinking + context7 MCP servers

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,21 +1,3 @@
 {
-  "mcpServers": {
-    "sequential-thinking": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-sequential-thinking"
-      ]
-    },
-    "context7": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@upstash/context7-mcp@latest"
-      ],
-      "env": {
-        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
-      }
-    }
-  }
+  "mcpServers": {}
 }


### PR DESCRIPTION
sequential-thinking is no longer used (native model reasoning suffices) and context7 is redundant with the ctx7 CLI workflow. Removing both eliminates the per-session MCP node processes (~390MB) they spawned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)